### PR TITLE
fix: surface validation issues in update and delete error output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ obsidian-help/
 
 # Test artifacts
 .mdbase-test-*/
+test/fixtures/strict-collection/.mdbase/

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { Collection } from "@callumalpass/mdbase";
 import type { MdbaseError } from "@callumalpass/mdbase";
 import yaml from "js-yaml";
-import { finishCommand, parseFieldValue } from "../utils.js";
+import { finishCommand, formatIssue, parseFieldValue } from "../utils.js";
 
 function parseFields(fieldArgs: string[]): Record<string, unknown> | null {
   const frontmatter: Record<string, unknown> = {};
@@ -93,19 +93,6 @@ export function registerCreate(program: Command): void {
       const exitCode = outputResult(result, relativePath, opts);
       await finishCommand(collection, exitCode);
     });
-}
-
-function formatIssue(issue: MdbaseError): string {
-  const severity = issue.severity ?? "error";
-  const tag =
-    severity === "error"
-      ? chalk.red("error")
-      : severity === "warning"
-        ? chalk.yellow("warn")
-        : chalk.blue("info");
-
-  const field = issue.field ? ` field ${chalk.bold(issue.field)}` : "";
-  return `  ${tag}${field}: ${issue.message} ${chalk.dim(`[${issue.code}]`)}`;
 }
 
 function outputResult(

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,8 +2,9 @@ import { Command } from "commander";
 import path from "node:path";
 import chalk from "chalk";
 import { Collection } from "@callumalpass/mdbase";
+import type { MdbaseError } from "@callumalpass/mdbase";
 import yaml from "js-yaml";
-import { finishCommand } from "../utils.js";
+import { finishCommand, formatIssue } from "../utils.js";
 
 export function registerDelete(program: Command): void {
   program
@@ -38,10 +39,20 @@ export function registerDelete(program: Command): void {
           : result.error.code === "permission_denied" ? 5
           : 1;
 
+        const issues = (result as { issues?: MdbaseError[] }).issues;
         if (opts.format === "json") {
-          console.log(JSON.stringify({ error: result.error }, null, 2));
+          const output: Record<string, unknown> = { error: result.error };
+          if (issues) {
+            output.issues = issues;
+          }
+          console.log(JSON.stringify(output, null, 2));
         } else {
           console.error(chalk.red(`error: ${result.error.message}`));
+          if (issues) {
+            for (const issue of issues) {
+              console.error(formatIssue(issue));
+            }
+          }
         }
         await finishCommand(collection, exitCode);
         return;

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,8 +2,9 @@ import { Command } from "commander";
 import path from "node:path";
 import chalk from "chalk";
 import { Collection } from "@callumalpass/mdbase";
+import type { MdbaseError } from "@callumalpass/mdbase";
 import yaml from "js-yaml";
-import { finishCommand, parseFieldValue } from "../utils.js";
+import { finishCommand, formatIssue, parseFieldValue } from "../utils.js";
 
 function parseFields(fieldArgs: string[]): Record<string, unknown> | null {
   const fields: Record<string, unknown> = {};
@@ -97,10 +98,20 @@ export function registerUpdate(program: Command): void {
           : result.error.code === "permission_denied" ? 5
           : 1;
 
+        const issues = (result as { issues?: MdbaseError[] }).issues;
         if (opts.format === "json") {
-          console.log(JSON.stringify({ error: result.error }, null, 2));
+          const output: Record<string, unknown> = { error: result.error };
+          if (issues) {
+            output.issues = issues;
+          }
+          console.log(JSON.stringify(output, null, 2));
         } else {
           console.error(chalk.red(`error: ${result.error.message}`));
+          if (issues) {
+            for (const issue of issues) {
+              console.error(formatIssue(issue));
+            }
+          }
         }
         await finishCommand(collection, exitCode);
         return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,22 @@
+import chalk from "chalk";
+import type { MdbaseError } from "@callumalpass/mdbase";
+
 type ClosableCollection = {
   close(): Promise<void>;
 };
+
+export function formatIssue(issue: MdbaseError): string {
+  const severity = issue.severity ?? "error";
+  const tag =
+    severity === "error"
+      ? chalk.red("error")
+      : severity === "warning"
+        ? chalk.yellow("warn")
+        : chalk.blue("info");
+
+  const field = issue.field ? ` field ${chalk.bold(issue.field)}` : "";
+  return `  ${tag}${field}: ${issue.message} ${chalk.dim(`[${issue.code}]`)}`;
+}
 
 export async function finishCommand(
   collection: ClosableCollection | null | undefined,

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -142,6 +142,35 @@ describe("create command", () => {
     });
   });
 
+  describe("validation issues", () => {
+    it("includes issues in JSON output when validation fails", () => {
+      const file = trackFile("create-invalid.md");
+      const { stdout, exitCode } = run(
+        ["create", file, "-t", "note", "-f", "rating=10", "--format", "json"],
+        VALID,
+      );
+      expect(exitCode).toBe(2);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.error.code).toBe("validation_failed");
+      expect(parsed.issues).toBeInstanceOf(Array);
+      const codes = parsed.issues.map((i: { code: string }) => i.code);
+      expect(codes).toContain("missing_required");
+      expect(codes).toContain("number_too_large");
+    });
+
+    it("prints issues in text output when validation fails", () => {
+      const file = trackFile("create-invalid.md");
+      const { exitCode, stderr } = run(
+        ["create", file, "-t", "note", "-f", "rating=10"],
+        VALID,
+      );
+      expect(exitCode).toBe(2);
+      expect(stderr).toContain("Validation failed on create");
+      expect(stderr).toContain("missing_required");
+      expect(stderr).toContain("number_too_large");
+    });
+  });
+
   describe("error handling", () => {
     it("exits 1 for path conflict", () => {
       const { exitCode, stderr } = run(

--- a/test/fixtures/strict-collection/_types/note.md
+++ b/test/fixtures/strict-collection/_types/note.md
@@ -1,0 +1,11 @@
+---
+name: note
+fields:
+  title:
+    type: string
+    required: true
+  rating:
+    type: integer
+    min: 1
+    max: 5
+---

--- a/test/fixtures/strict-collection/hello.md
+++ b/test/fixtures/strict-collection/hello.md
@@ -1,0 +1,7 @@
+---
+type: note
+title: Hello World
+rating: 5
+---
+
+This is a valid note.

--- a/test/fixtures/strict-collection/mdbase.yaml
+++ b/test/fixtures/strict-collection/mdbase.yaml
@@ -1,0 +1,4 @@
+spec_version: "0.2.0"
+name: strict-collection
+settings:
+  default_validation: error

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 const CLI = path.resolve(__dirname, "../src/cli.ts");
 const TSX_CLI = path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs");
 const VALID = path.resolve(__dirname, "fixtures/valid-collection");
+const STRICT = path.resolve(__dirname, "fixtures/strict-collection");
 
 function run(args: string[], cwd: string): { stdout: string; stderr: string; exitCode: number } {
   try {
@@ -193,6 +194,33 @@ describe("update command", () => {
       );
       expect(exitCode).toBe(1);
       expect(stderr).toContain("invalid field format");
+    });
+  });
+
+  describe("validation issues", () => {
+    it("includes issues in JSON output when validation fails", () => {
+      const { stdout, exitCode } = run(
+        ["update", "hello.md", "-f", "rating=10", "--format", "json"],
+        STRICT,
+      );
+      expect(exitCode).toBe(2);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.error.code).toBe("validation_failed");
+      expect(parsed.issues).toBeInstanceOf(Array);
+      expect(parsed.issues.length).toBeGreaterThan(0);
+      expect(parsed.issues[0].field).toBe("rating");
+      expect(parsed.issues[0].code).toBe("number_too_large");
+    });
+
+    it("prints issues in text output when validation fails", () => {
+      const { exitCode, stderr } = run(
+        ["update", "hello.md", "-f", "rating=10"],
+        STRICT,
+      );
+      expect(exitCode).toBe(2);
+      expect(stderr).toContain("Validation failed on update");
+      expect(stderr).toContain("rating");
+      expect(stderr).toContain("number_too_large");
     });
   });
 


### PR DESCRIPTION
## Problem

When `collection.update()` rejects a write, the library returns both `result.error` **and** `result.issues` (an array of `{code, message, field, severity}`), but the `update` command prints only `error.message` ("Validation failed on update") and discards the issues in both text and `--format json` output.

That makes validation failures undiagnosable from the CLI — you can't see which field failed or why. In practice this hid a real library bug for a while (see callumalpass/mdbase#3, where a generated date field caused every `update` to fail with nothing but the one-line message).

Before:

```
$ mdbase update hello.md -f rating=10
error: Validation failed on update
```

After:

```
$ mdbase update hello.md -f rating=10
error: Validation failed on update
  error field rating: Integer "rating" is too large (10 > 5) [number_too_large]
```

and in JSON:

```json
{
  "error": { "code": "validation_failed", "message": "Validation failed on update" },
  "issues": [
    { "code": "number_too_large", "message": "Integer \"rating\" is too large (10 > 5)", "field": "rating", "severity": "error" }
  ]
}
```

## Changes

- **`update`**: include `issues` in JSON error output and print them as indented lines in text output — same format `create` already uses.
- **`delete`**: same passthrough for output-contract parity. (No library code path returns `issues` on delete today, so this is defensive; happy to drop it if you'd rather not carry the dead branch.)
- **`utils.ts`**: `formatIssue` moved here from `create.ts` so all three commands share it. No behavior change for `create`.
- **Tests**: new `test/fixtures/strict-collection` fixture with `default_validation: error` (the default `warn` level never rejects updates, so the existing fixture can't trigger this path). Two new update tests (JSON + text), plus regression tests pinning `create`'s existing issue output. Fixture's `.mdbase/` cache dir is gitignored.

## Testing

- New update tests written first and confirmed failing against the old code (issues absent from both formats), then passing with the fix.
- Full suite: 269/269 passing, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)