### PR TITLE
Retire the TypeScript mdbase CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Add `view run` and `view validate` for canonical v0.3 Markdown view records,
   including explicit invocation context and headless result formats.
+- Retire the TypeScript executable in favor of the unified native Rust
+  `mdbase` CLI.
+- Mark the package private and remove all package-manager binary and library
+  entry points.
+- Preserve the historical implementation only as a capability-migration
+  reference; TypeScript SDK packages are unaffected.
 
 ## 0.3.0-rc.1 - 2026-07-19
 - Publish the first v0.3 release candidate against the registry-hosted mdbase core package.

--- a/README.md
+++ b/README.md
@@ -1,174 +1,27 @@
-# mdbase-cli
+# mdbase-cli (retired TypeScript implementation)
 
-Command-line tool for working with [mdbase](https://github.com/callumalpass/mdbase) collections. Validates, queries, executes portable Markdown view records, and performs CRUD operations on markdown document collections. It can also execute Obsidian `.base` files.
+This repository is retained as a migration reference only. It no longer
+publishes or installs an `mdbase` executable.
 
-## Install
-
-Requires Node.js 22+.
-
-### Recommended (npm global install)
-
-```sh
-npm install -g mdbase-cli
-mdbase --help
-```
-
-This installs both `mdbase` and `mdbase-fzf` on your `PATH`.
-
-### Project-local install
+The supported CLI is the native Rust `mdbase` executable built by
+[`mdbase-connect`](https://github.com/mdbase-dev/mdbase-connect). It combines
+the canonical `mdbase-rs` collection engine with direct filesystem access,
+Connect-managed collection access, daemon/service management, and built-in
+performance profiling.
 
 ```sh
-npm install --save-dev mdbase-cli
-npx mdbase --help
+mdbase --root ./notes validate
+mdbase --root ./notes query --types task
+mdbase --collection <uuid> query --types task
+mdbase connect status
+mdbase profile engine
 ```
 
-### Development from source
+The historical source and tests remain readable so that intentionally
+non-core presentation features can be evaluated without preserving a second
+collection engine. See [RETIREMENT.md](RETIREMENT.md) for the capability map
+and decisions.
 
-```sh
-git clone https://github.com/callumalpass/mdbase-cli.git
-cd mdbase-cli
-npm ci
-npm run build
-node dist/cli.js --help
-```
-
-## Usage
-
-```
-mdbase <command> [options]
-```
-
-Global option:
-
-- `-C, --collection <alias>` Run a command against a registered collection alias (from `mdbase collections add`).
-
-### Core commands
-
-| Command    | Description                                      |
-|------------|--------------------------------------------------|
-| `validate` | Validate documents against their type schemas    |
-| `query`    | Query documents with filters and sorting         |
-| `view`     | Validate or execute portable Markdown views      |
-| `read`     | Read a single document by path or ID             |
-| `create`   | Create a new document                            |
-| `update`   | Update an existing document                      |
-| `delete`   | Delete a document                                |
-| `rename`   | Rename a document                                |
-| `types`    | List or inspect registered types                 |
-| `migrate v0.3` | Analyze or safely apply a v0.2-to-v0.3 migration |
-
-### Obsidian Bases
-
-| Command    | Description                                      |
-|------------|--------------------------------------------------|
-| `base run` | Execute an Obsidian `.base` file                 |
-
-### Additional commands
-
-| Command    | Description                                      |
-|------------|--------------------------------------------------|
-| `init`     | Initialize a new mdbase collection               |
-| `lint`     | Lint documents for common issues                 |
-| `fmt`      | Format document frontmatter                      |
-| `export`   | Export documents to CSV or JSON                  |
-| `import`   | Import documents from CSV or JSON                |
-| `graph`    | Show link graph between documents                |
-| `stats`    | Print collection statistics                      |
-| `watch`    | Watch for file changes and re-validate           |
-| `diff`     | Show differences between document versions       |
-| `schema`   | Generate or inspect type schemas                 |
-| `collections` | Manage named collection registry entries      |
-
-### Fuzzy picker
-
-`mdbase-fzf` provides an interactive two-step picker powered by `fzf`:
-
-1. Choose a type (includes `untype` for files without a type).
-2. Browse matching files with key fields (display/title-style fields are prioritized), preview, then open in your editor.
-
-Requirements: `fzf` and `jq` on `PATH`.
-
-```sh
-mdbase-fzf
-```
-
-## Examples
-
-Validate all documents in the current directory:
-
-```sh
-mdbase validate .
-```
-
-Query documents of a given type:
-
-```sh
-mdbase query "status = published" --types note --sort created --limit 10
-```
-
-`query` defaults to `--format paths` for fast output on large vaults. Use `--format table` for tabular display.
-
-Execute an Obsidian `.base` file:
-
-```sh
-mdbase base run my-view.base
-```
-
-Execute a portable named view with a fixed invocation context:
-
-```sh
-mdbase view run views/tasks.md --view project-open --context projects/alpha.md
-mdbase view validate views/tasks.md
-```
-
-Analyze a v0.2 collection without changing it, review the diff and JSON report,
-then apply that exact analysis with backup and rollback protection:
-
-```sh
-mdbase migrate v0.3 analyze --report migration-report.json
-mdbase migrate v0.3 apply --report migration-report.json --yes
-mdbase migrate v0.3 recover --backup .mdbase/migrations/v0.3-<id> --yes
-```
-
-Apply writes a durable backup manifest before replacing files and journals each
-atomic replacement. `recover` verifies backup hashes before restoring an
-interrupted or applied migration and reports any paths that require manual
-recovery.
-
-Analysis exits with status 2 when records are incompatible or features need
-manual handling. Applying such a report additionally requires
-`--allow-partial`.
-
-Export to CSV:
-
-```sh
-mdbase export . --type note --format csv -o notes.csv
-```
-
-Initialize and register a collection alias:
-
-```sh
-mdbase init --name Work --example-type task --register work
-```
-
-`init` creates a v0.3 collection by default. Use `--spec-version 0.2.1` only when a legacy consumer requires the v0.2 type grammar.
-
-List markdown files from all registered collections:
-
-```sh
-mdbase collections files --format paths
-```
-
-## Example applications
-
-| Project | Description |
-|---------|-------------|
-| [mdbase-workouts](https://github.com/callumalpass/mdbase-workouts) | Workout tracker with chat interface, built on mdbase |
-
-## Spec
-
-mdbase-cli implements the [mdbase specification](https://github.com/callumalpass/mdbase-spec).
-
-## License
-
-MIT
+Do not publish this package, add a package-manager `bin` entry, or implement
+new collection behavior here. TypeScript application SDKs are separate
+packages and are not retired by this change.

--- a/RETIREMENT.md
+++ b/RETIREMENT.md
@@ -1,0 +1,64 @@
+# TypeScript CLI retirement and capability map
+
+## Decision
+
+There is one supported executable: native Rust `mdbase`.
+
+The final executable lives in `mdbase-connect`, imports the transport-neutral
+`mdbase-command` crate from `mdbase-rs`, and selects either a direct filesystem
+target (`--root PATH`) or a Connect daemon target (`--collection UUID`). The
+engine does not import Connect. This repository is private, exports no package
+binary, and remains only as readable migration history.
+
+## Capabilities consolidated into Rust
+
+| TypeScript surface | Unified native surface | Canonical implementation |
+| --- | --- | --- |
+| `init` | `mdbase init` | `mdbase-rs` |
+| `read`, `create`, `update`, `delete`, `rename` | same top-level commands | typed CRUD operations |
+| `query` | `mdbase query` | canonical query operation and SQLite accelerator |
+| `validate` | `mdbase validate` | collection validation |
+| `types list/show/create` | `mdbase types list/show/create/update` | canonical type-resource operations |
+| `view run`, `view validate`, `base run` | `mdbase views execute`, `mdbase validate` | canonical saved-view engine |
+| `watch` | `mdbase watch` | normalized portable Watch-profile events |
+| `migrate v0.3` | `mdbase migrate-v02` | verified crash-recoverable migration |
+| collection aliases | `--root` or Connect collection UUIDs | explicit target selection and daemon registry |
+| mutation composition | `mdbase batch` | typed, journalled batch operation |
+| maintenance | `mdbase backfill`, `migrate`, and `cache` | canonical engine maintenance |
+
+All portable record commands can use the same syntax through the daemon by
+supplying `--collection UUID`. Direct-only filesystem maintenance fails before
+daemon contact rather than changing meaning.
+
+## Historical utilities intentionally not promoted into the core
+
+The following commands were presentation, interchange, or exploratory tools
+rather than collection semantics:
+
+- `fmt`
+- `diff`
+- `export` and `import`
+- `graph`
+- `stats`
+- `lint`
+- `schema infer`
+- the `mdbase-fzf` shell helper
+
+They are not reasons to keep a second CLI or engine. A utility may return later
+only when it has a clear product use case, consumes canonical Rust operation
+results, and lives behind a small adapter boundary. It must not parse,
+validate, mutate, or index collections independently. Import must use typed
+batch operations; export and reports must use paginated queries; formatting
+must use a canonical engine-owned rewrite operation if one is specified.
+
+## Release gate
+
+Before the first public native release:
+
+1. pin immutable `mdbase-rs` and Connect dependency revisions;
+2. publish/install only the native `mdbase` executable;
+3. mark the old npm package deprecated if it has ever been published;
+4. verify direct-versus-daemon result parity for every portable command;
+5. run deterministic performance budgets and packaged desktop smoke tests;
+6. ensure documentation and automation contain no dependency on the former
+   TypeScript executable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,6 @@
         "picomatch": "^4.0.5",
         "proper-lockfile": "^4.1.2"
       },
-      "bin": {
-        "mdbase": "dist/cli.js",
-        "mdbase-fzf": "mdbase-fzf"
-      },
       "devDependencies": {
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mdbase-cli",
+  "private": true,
   "version": "0.3.0-rc.1",
-  "description": "CLI tool for mdbase collections — validate, query, run Markdown views, CRUD, and execute Obsidian .base files",
+  "description": "Retired TypeScript reference implementation of the mdbase CLI",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,17 +13,11 @@
   },
   "homepage": "https://github.com/callumalpass/mdbase-cli#readme",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "bin": {
-    "mdbase": "dist/cli.js",
-    "mdbase-fzf": "mdbase-fzf"
-  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",
-    "test:package": "npm run build && node scripts/smoke-package.mjs",
+    "test:package": "node scripts/smoke-package.mjs",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -46,12 +41,5 @@
     "typescript": "^5.5.0",
     "vitest": "^4.1.10"
   },
-  "files": [
-    "dist",
-    "vendor",
-    "README.md",
-    "LICENSE",
-    "CHANGELOG.md",
-    "mdbase-fzf"
-  ]
+  "files": []
 }

--- a/scripts/smoke-package.mjs
+++ b/scripts/smoke-package.mjs
@@ -1,47 +1,48 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const packageRoot = resolve(import.meta.dirname, "..");
-const tempRoot = mkdtempSync(join(tmpdir(), "mdbase-cli-package-smoke-"));
-let tarball;
+const manifest = JSON.parse(
+  readFileSync(resolve(packageRoot, "package.json"), "utf8"),
+);
 
-function runNpm(args, options) {
-  if (process.env.npm_execpath) {
-    return execFileSync(process.execPath, [process.env.npm_execpath, ...args], options);
+if (manifest.private !== true) {
+  throw new Error("The retired TypeScript package must remain private");
+}
+for (const entrypoint of ["main", "types", "bin"]) {
+  if (entrypoint in manifest) {
+    throw new Error(`The retired package must not expose a ${entrypoint} entry point`);
   }
-  return execFileSync("npm", args, { ...options, shell: process.platform === "win32" });
+}
+if (!Array.isArray(manifest.files) || manifest.files.length !== 0) {
+  throw new Error("The retired package must have an explicitly empty files allowlist");
 }
 
-try {
-  const packed = JSON.parse(
-    runNpm(["pack", "--json"], {
+const runNpm = (args) => {
+  if (process.env.npm_execpath) {
+    return execFileSync(process.execPath, [process.env.npm_execpath, ...args], {
       cwd: packageRoot,
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "inherit"],
-    }),
-  );
-  tarball = resolve(packageRoot, packed[0].filename);
-
-  writeFileSync(
-    join(tempRoot, "package.json"),
-    JSON.stringify({ name: "mdbase-cli-package-smoke", private: true }),
-  );
-  runNpm(["install", "--ignore-scripts", tarball], {
-    cwd: tempRoot,
-    stdio: "inherit",
-  });
-
-  const cli = join(tempRoot, "node_modules", "mdbase-cli", "dist", "cli.js");
-  const version = execFileSync(process.execPath, [cli, "--version"], {
-    cwd: tempRoot,
-    encoding: "utf8",
-  }).trim();
-  if (version !== "0.3.0-rc.1") {
-    throw new Error(`Unexpected installed CLI version: ${version}`);
+    });
   }
-} finally {
-  if (tarball) rmSync(tarball, { force: true });
-  rmSync(tempRoot, { recursive: true, force: true });
+  return execFileSync("npm", args, {
+    cwd: packageRoot,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+};
+
+const packed = JSON.parse(runNpm(["pack", "--dry-run", "--json"]));
+const files = packed[0]?.files?.map((file) => file.path) ?? [];
+const forbidden = files.filter(
+  (path) =>
+    path === "mdbase-fzf" ||
+    path === "dist/cli.js" ||
+    path.startsWith("dist/"),
+);
+if (forbidden.length > 0) {
+  throw new Error(
+    `The retired package still includes executable output: ${forbidden.join(", ")}`,
+  );
 }


### PR DESCRIPTION
## What changed

- marked the npm package private
- removed its library and executable entry points, including `mdbase` and `mdbase-fzf`
- replaced the README with the native CLI handoff
- added a detailed capability/retirement map for the historical TypeScript commands
- replaced the old installed-CLI package smoke with a negative retirement guard that rejects executable/package payload regressions
- retained source and tests only as migration history

## Why

Maintaining two collection CLIs duplicates parsing, validation, mutation, indexing, and lifecycle behavior. The supported surface is now the native Rust `mdbase` executable assembled in `mdbase-connect`, while TypeScript SDK packages remain unaffected.

## Impact

This repository no longer publishes or installs a CLI. Historical non-core utilities can only return as thin consumers of canonical native operations, not as another engine.

## Validation

- `npm ci`
- `npm test` (23 files, 271 tests)
- `npm run build`
- `npm run test:package`
- package metadata and dry-run packing confirm `private: true`, no `main`/`types`/`bin`, no packaged `dist`, and no `mdbase-fzf`